### PR TITLE
Fix simulator timing by using nanosleep() instead of the ARM-calibrated nop loop.

### DIFF
--- a/firmware/basic/delayms.c
+++ b/firmware/basic/delayms.c
@@ -1,6 +1,21 @@
+#ifdef SIMULATOR
+#define _POSIX_C_SOURCE 199309
+#include <time.h>
+#endif
+
 #include <sysdefs.h>
 #include "lpc134x.h"
 
+#ifdef SIMULATOR
+void delayms(uint32_t ms)
+{
+  struct timespec t;
+  t.tv_sec = ms / 1000;
+  t.tv_nsec = (ms % 1000) * 1000000;
+
+  nanosleep (&t, NULL);
+}
+#else
 /**************************************************************************/
 /*! 
     Approximates a 1 millisecond delay using "nop".  This is less
@@ -22,3 +37,4 @@ void delayms(uint32_t ms)
     delay--;
   }
 }
+#endif


### PR DESCRIPTION
Use nanosleep() for the simulator for a better timing, since the nop loop is not really calibrated to my Core i5...
