### PR TITLE
add missing #include<unistd.h> to simulato0r/gui/qsimulat0r.cc

### DIFF
--- a/simulat0r/gui/qsimulat0r.cc
+++ b/simulat0r/gui/qsimulat0r.cc
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <time.h>
+#include <unistd.h>
 #include <QApplication>
 #include <QImage>
 #include <QKeyEvent>


### PR DESCRIPTION
#include <unistd.h> 
to get rid of usleep(10000) not defined error